### PR TITLE
Post github status with the context "jenkins"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
 void setBuildStatus(String message, String state) {
   step([
     $class: "GitHubCommitStatusSetter",
+    reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/n1analytics/clkhash"],
+    contextSource: [$class: 'ManuallyEnteredCommitContextSource', context: 'jenkins'],
     statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
   ]);
 }


### PR DESCRIPTION
- Allows jenkins to identify the repo of a new branch with only one commit
- Sets the context jenkins uses when posting a status check to github - which allows us to specify that a particular status check (e.g. the jenkins unit tests pass) is required before merging.