### PR TITLE
Fix #246

### DIFF
--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -209,7 +209,7 @@ def blake_encode_ngrams(ngrams,   # type: Iterable[str]
         :return: bitarray of length l with the bits set which correspond to the
                  encoding of the ngrams
     """
-    key, = keys  # Unpack.
+    key = keys[0]  # We only need the first key
 
     log_l = int(math.log(l, 2))
     if not 2 ** log_l == l:


### PR DESCRIPTION
fixes issue #246

The underlying problem is that 
- Blake hash requires one key, whereas double hash needs two
- we can define the hash type on a per field basis
- clkutil enforces users to input two secrets

The Blake hash function breaks if called with two secrets. However, you cannot avoid calling it with two keys, if you have 
- mixed hash types in the schema
- used clkutil

This is a quick fix. We should probably rethink the key derivation such that we generate only the keys needed from _one_ secret.