### PR TITLE
Testing ignored

### DIFF
--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -849,8 +849,11 @@ def spec_from_json_dict(
         :returns: An initialised instance of the appropriate FieldSpec
             subclass.
     """
-    if 'ignored' in json_dict:
-        return Ignore(json_dict['identifier'])
-    type_str = json_dict['format']['type']
-    spec_type = cast(FieldSpec, FIELD_TYPE_MAP[type_str])
+    try:
+        if json_dict.get('ignored', False):
+            return Ignore(json_dict['identifier'])
+        type_str = json_dict['format']['type']
+        spec_type = cast(FieldSpec, FIELD_TYPE_MAP[type_str])
+    except KeyError as e:
+        raise InvalidSchemaError("the feature definition {} is incomplete. Must contain: {}".format(json_dict, e))
     return spec_type.from_json_dict(json_dict)

--- a/tests/test_field_formats.py
+++ b/tests/test_field_formats.py
@@ -465,3 +465,36 @@ class TestFieldFormats(unittest.TestCase):
         self.assertEqual(spec.hashing_properties.missing_value.replace_with,
                          spec.hashing_properties.replace_missing_value(''))
 
+    def test_ignored(self):
+        spec_dict = {
+            'identifier': 'testingIgnored',
+            'ignored': True}
+        spec = field_formats.spec_from_json_dict(spec_dict)
+        # clkhash handles ingored fields by setting hashing properties to None.
+        self.assertIsNone(spec.hashing_properties)
+        self.assertEqual(spec.identifier, 'testingIgnored')
+        spec_dict = {
+            'identifier': 'testingIgnored',
+            'ignored': False}
+        with self.assertRaises(field_formats.InvalidEntryError):
+            field_formats.spec_from_json_dict(spec_dict)
+        spec_dict = {
+            'identifier': 'ignoredDates',
+            'ignored': True,
+            'format': {
+                'type': 'date', 'format': '%Y-%m-%d'},
+            'hashing': {'ngram': 0, 'strategy': {'k': 20}}
+        }
+        spec = field_formats.spec_from_json_dict(spec_dict)
+        self.assertIsNone(spec.hashing_properties)
+        self.assertEqual(spec.identifier, 'ignoredDates')
+        spec_dict = {
+            'identifier': 'notIgnoredDates',
+            'ignored': False,
+            'format': {
+                'type': 'date', 'format': '%Y-%m-%d'},
+            'hashing': {'ngram': 0, 'strategy': {'k': 20}}
+        }
+        spec = field_formats.spec_from_json_dict(spec_dict)
+        self.assertIsNotNone(spec.hashing_properties)
+        self.assertEqual(spec.identifier, 'notIgnoredDates')

--- a/tests/test_field_formats.py
+++ b/tests/test_field_formats.py
@@ -470,13 +470,12 @@ class TestFieldFormats(unittest.TestCase):
             'identifier': 'testingIgnored',
             'ignored': True}
         spec = field_formats.spec_from_json_dict(spec_dict)
-        # clkhash handles ingored fields by setting hashing properties to None.
-        self.assertIsNone(spec.hashing_properties)
+        self.assertIsInstance(spec, field_formats.Ignore)
         self.assertEqual(spec.identifier, 'testingIgnored')
         spec_dict = {
             'identifier': 'testingIgnored',
             'ignored': False}
-        with self.assertRaises(field_formats.InvalidEntryError):
+        with self.assertRaises(field_formats.InvalidSchemaError):
             field_formats.spec_from_json_dict(spec_dict)
         spec_dict = {
             'identifier': 'ignoredDates',
@@ -486,7 +485,7 @@ class TestFieldFormats(unittest.TestCase):
             'hashing': {'ngram': 0, 'strategy': {'k': 20}}
         }
         spec = field_formats.spec_from_json_dict(spec_dict)
-        self.assertIsNone(spec.hashing_properties)
+        self.assertIsInstance(spec, field_formats.Ignore)
         self.assertEqual(spec.identifier, 'ignoredDates')
         spec_dict = {
             'identifier': 'notIgnoredDates',
@@ -497,4 +496,5 @@ class TestFieldFormats(unittest.TestCase):
         }
         spec = field_formats.spec_from_json_dict(spec_dict)
         self.assertIsNotNone(spec.hashing_properties)
+        self.assertIsInstance(spec, field_formats.DateSpec)
         self.assertEqual(spec.identifier, 'notIgnoredDates')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import unittest
+from jsonschema import ValidationError
 
 from clkhash import schema
 from clkhash.schema import SchemaError, MasterSchemaError
@@ -95,6 +96,24 @@ class TestSchemaValidation(unittest.TestCase):
         schema_repr = repr(s)
         assert "v2" in schema_repr
         assert "12 fields" in schema_repr
+
+    def test_validation_of_invalid_ignored(self):
+        schema_dict = {
+            'version': 2,
+            'clkConfig': {
+                'l': 1024,
+                'kdf': {
+                    'type': 'HKDF'}},
+            'features': [
+                {
+                    'identifier': 'rec_id',
+                    'ignored': False}]
+        }
+        try:
+            schema.from_json_dict(schema_dict)
+        except Exception as e:
+            # checking that jsonschema validation failed
+            self.assertTrue(isinstance(e.__cause__, ValidationError))
 
 
 class TestSchemaLoading(unittest.TestCase):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -97,7 +97,8 @@ class TestSchemaValidation(unittest.TestCase):
         assert "v2" in schema_repr
         assert "12 fields" in schema_repr
 
-    def test_validation_of_invalid_ignored(self):
+    def test_validation_of_illdefined_not_ignored_feature(self):
+        # 'ignored' has to be true if 'format' and 'hashing' is missing
         schema_dict = {
             'version': 2,
             'clkConfig': {
@@ -109,11 +110,11 @@ class TestSchemaValidation(unittest.TestCase):
                     'identifier': 'rec_id',
                     'ignored': False}]
         }
-        try:
+        with self.assertRaises(Exception) as contextmanager:
             schema.from_json_dict(schema_dict)
-        except Exception as e:
-            # checking that jsonschema validation failed
-            self.assertTrue(isinstance(e.__cause__, ValidationError))
+
+        exception = contextmanager.exception
+        self.assertIsInstance(exception.__cause__, ValidationError)
 
 
 class TestSchemaLoading(unittest.TestCase):


### PR DESCRIPTION
I wrote some tests to check if the handling of 'Ignored' features is correct.
More specifically, I want good failures.
Currently one test fails, because field_formats raises an `InvalidSchemaError`, caused by `KeyError`.
I argue that this should be an `InvalidEntryError`. (see descriptions of InvalidSchemaError and InvalidEntryError). 

More generally, I want to be allowed:
```
{
    "identifier": "good",
    "ignored": true
}
```
```
{
   "identifier": "good_with_format",
    "ignored": true,
    "format": {
        "type": "date", "format": "%Y-%m-%d"},
        "hashing": {"ngram": 1, "strategy": {"k": 20}}
}
```
```
{
   "identifier": "good_with_format",
    "ignored": false,
    "format": {
        "type": "date", "format": "%Y-%m-%d"},
        "hashing": {"ngram": 1, "strategy": {"k": 20}}
}
```
but not
```
{
    "identifier": "good",
    "ignored": false
}
```

Once we agree on the correct handling, I'll write the corresponding fix. 
So for now, just comment (dis)agreement. 