### PR TITLE
Fix tokenizer

### DIFF
--- a/clkhash/tokenizer.py
+++ b/clkhash/tokenizer.py
@@ -56,6 +56,9 @@ def get_tokenizer(fhp  # type: Optional[field_formats.FieldHashingProperties]
         if ignore is not None:
             word = word.replace(ignore, '')
 
+        if len(word) == 0:
+            return tuple()
+
         if n > 1:
             word = ' {} '.format(word)
 

--- a/docs/tutorial_api.ipynb
+++ b/docs/tutorial_api.ipynb
@@ -362,7 +362,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "generating CLKs: 100%|██████████| 5.00k/5.00k [00:01<00:00, 786clk/s, mean=950, std=9.79]\n"
+      "generating CLKs: 100%|██████████| 5.00k/5.00k [00:03<00:00, 1.26kclk/s, mean=946, std=14.2]\n"
      ]
     }
    ],
@@ -399,14 +399,16 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "generating CLKs: 100%|██████████| 5.00k/5.00k [00:00<00:00, 1.41kclk/s, mean=705, std=15.5]\n"
+      "generating CLKs: 100%|██████████| 5.00k/5.00k [00:02<00:00, 1.96kclk/s, mean=698, std=22.8]\n"
      ]
     }
    ],
@@ -443,7 +445,9 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [
     {
@@ -476,14 +480,16 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "generating CLKs: 100%|██████████| 5.00k/5.00k [00:00<00:00, 1.45kclk/s, mean=703, std=19.1]\n"
+      "generating CLKs: 100%|██████████| 5.00k/5.00k [00:01<00:00, 1.92kclk/s, mean=689, std=30.8]\n"
      ]
     }
    ],
@@ -498,7 +504,9 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [
     {
@@ -535,7 +543,9 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [],
    "source": [
@@ -572,7 +582,9 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [],
    "source": [
@@ -593,14 +605,16 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found 4019 matches\n"
+      "Found 4058 matches\n"
      ]
     }
    ],
@@ -621,7 +635,9 @@
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [],
    "source": [
@@ -670,7 +686,9 @@
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [
     {
@@ -690,8 +708,8 @@
       " 10,   3630,     rec-453-org,   rec-453-dup-0\n",
       "---------------------------------------------\n",
       "\n",
-      "We've got 4019 true positives, 0 false positives, and 981 false negatives.\n",
-      "Precision: 1.000, Recall: 0.804, Accuracy: 0.804\n"
+      "We've got 4058 true positives, 0 false positives, and 942 false negatives.\n",
+      "Precision: 1.000, Recall: 0.812, Accuracy: 0.812\n"
      ]
     }
    ],
@@ -705,7 +723,7 @@
     "pycharm": {}
    },
    "source": [
-    "Precision tells us about how many of the found matches are actual matches. The score of 1.0 means that we did perfectly in this respect, however, recall, the measure of how many of the actual matches were correctly identified, is quite low with only 80%.\n",
+    "Precision tells us about how many of the found matches are actual matches. The score of 1.0 means that we did perfectly in this respect, however, recall, the measure of how many of the actual matches were correctly identified, is quite low with only 81%.\n",
     "\n",
     "Let's go back to the mapping calculation (`calculate_mapping_greedy`) an reduce the value for `threshold` to `0.8`."
    ]
@@ -714,17 +732,19 @@
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found 4974 matches\n",
+      "Found 4966 matches\n",
       "\n",
-      "We've got 4974 true positives, 0 false positives, and 26 false negatives.\n",
-      "Precision: 1.000, Recall: 0.995, Accuracy: 0.995\n"
+      "We've got 4966 true positives, 0 false positives, and 34 false negatives.\n",
+      "Precision: 1.000, Recall: 0.993, Accuracy: 0.993\n"
      ]
     }
    ],
@@ -739,12 +759,19 @@
     "pycharm": {}
    },
    "source": [
-    "Great, for this threshold value we get a precision of 100% and a recall of 99.6%. \n",
+    "Great, for this threshold value we get a precision of 100% and a recall of 99.3%. \n",
     "\n",
-    "The explanation is that when the information about an entity differs slightly in the two datasets (e.g. spelling errors, abbrevations, missing values, ...) then the corresponding CLKs will differ in some number of bits as well. It is important to choose an appropriate threshold for the amount of perturbations present in the data (a threshold of 0.74 and below generates a mapping which misses just one true match).\n",
+    "The explanation is that when the information about an entity differs slightly in the two datasets (e.g. spelling errors, abbrevations, missing values, ...) then the corresponding CLKs will differ in some number of bits as well. It is important to choose an appropriate threshold for the amount of perturbations present in the data (a threshold of 0.72 and below generates a perfect mapping without mistakes).\n",
     "\n",
     "This concludes the tutorial. Feel free to go back to the CLK generation and experiment on how different setting will affect the matching quality."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -763,7 +790,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.3"
   },
   "pycharm": {
    "stem_cell": {

--- a/docs/tutorial_cli.ipynb
+++ b/docs/tutorial_cli.ipynb
@@ -380,7 +380,9 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "pycharm": {}
+    "tags": [
+     "nbval-ignore-output"
+    ]
    },
    "outputs": [
     {
@@ -454,7 +456,11 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/docs/tutorial_cli.ipynb
+++ b/docs/tutorial_cli.ipynb
@@ -384,10 +384,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mschema is valid\u001b[0m\r\n"
+      "schema is valid\n"
      ]
     }
    ],
@@ -416,11 +416,21 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "generating CLKs: 100%|█| 5.00k/5.00k [00:03<00:00, 1.07kclk/s, mean=945, std=14.2]\n",
-      "\u001b[31mCLK data written to clks_a.json\u001b[0m\n"
+      "\n",
+      "generating CLKs:   0%|          | 0.00/5.00k [00:00<?, ?clk/s, mean=0, std=0]\n",
+      "generating CLKs:   4%|4         | 200/5.00k [00:02<01:02, 76.6clk/s, mean=944, std=15.1]\n",
+      "generating CLKs:  24%|##4       | 1.20k/5.00k [00:02<00:34, 109clk/s, mean=945, std=14.3]\n",
+      "generating CLKs:  32%|###2      | 1.60k/5.00k [00:02<00:22, 153clk/s, mean=945, std=14.5]\n",
+      "generating CLKs:  40%|####      | 2.00k/5.00k [00:03<00:14, 211clk/s, mean=945, std=14.3]\n",
+      "generating CLKs:  48%|####8     | 2.40k/5.00k [00:03<00:08, 294clk/s, mean=945, std=14.4]\n",
+      "generating CLKs:  60%|######    | 3.00k/5.00k [00:03<00:04, 409clk/s, mean=945, std=14.3]\n",
+      "generating CLKs:  68%|######8   | 3.40k/5.00k [00:03<00:03, 514clk/s, mean=945, std=14.1]\n",
+      "generating CLKs:  76%|#######6  | 3.80k/5.00k [00:03<00:01, 685clk/s, mean=945, std=13.9]\n",
+      "generating CLKs: 100%|##########| 5.00k/5.00k [00:03<00:00, 931clk/s, mean=945, std=14.2]\n",
+      "CLK data written to clks_a.json\n"
      ]
     }
    ],
@@ -454,33 +464,33 @@
       "    |                                                       popcounts                                                        |\n",
       "    --------------------------------------------------------------------------------------------------------------------------\n",
       "\n",
-      " 617| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 585| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 552| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 520| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 487| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 455| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 422| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 390| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 357| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 325| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 293| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 260| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 228| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 195| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 163| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      " 130| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      "  98| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      "  65| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      "  33| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
-      "   1| \u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\n",
+      " 617|                                                o            \n",
+      " 585|                                                o            \n",
+      " 552|                                                o            \n",
+      " 520|                                                o            \n",
+      " 487|                                                o            \n",
+      " 455|                                                o            \n",
+      " 422|                                                o            \n",
+      " 390|                                                o   o        \n",
+      " 357|                                               oooo o        \n",
+      " 325|                                              ooooo o        \n",
+      " 293|                                              ooooooo        \n",
+      " 260|                                              ooooooo        \n",
+      " 228|                                           o oooooooo        \n",
+      " 195|                                           oooooooooo        \n",
+      " 163|                                           ooooooooooo       \n",
+      " 130|                                           ooooooooooo       \n",
+      "  98|                                      o  ooooooooooooo       \n",
+      "  65|                                  o oooooooooooooooooooo     \n",
+      "  33|                                oooooooooooooooooooooooo     \n",
+      "   1| o    o    o ooo oooooooooooooooooooooooooooooooooooooooooooo\n",
       "     ------------------------------------------------------------\n",
-      "\u001b[39m     \u001b[39m8 8 8 8 8 8 8 8 8 8 8 8 8 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 \n",
-      "\u001b[39m     \u001b[39m4 5 5 5 6 6 7 7 8 8 9 9 9 0 0 1 1 2 2 3 3 3 4 4 5 5 6 6 7 7 \n",
-      "\u001b[39m     \u001b[39m6 0 4 9 3 8 2 7 1 5 0 4 9 3 8 2 6 1 5 0 4 9 3 7 2 6 1 5 0 4 \n",
-      "\u001b[39m     \u001b[39m  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . \n",
-      "\u001b[39m     \u001b[39m  4 8 3 7 1 6 0 4 9 3 7 2 6 0 5 9 3 8 2 6 1 5 9 4 8 2 7 1 5 \n",
-      "\u001b[39m     \u001b[39m  3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 \n",
+      "     8 8 8 8 8 8 8 8 8 8 8 8 8 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 \n",
+      "     4 5 5 5 6 6 7 7 8 8 9 9 9 0 0 1 1 2 2 3 3 3 4 4 5 5 6 6 7 7 \n",
+      "     6 0 4 9 3 8 2 7 1 5 0 4 9 3 8 2 6 1 5 0 4 9 3 7 2 6 1 5 0 4 \n",
+      "       . . . . . . . . . . . . . . . . . . . . . . . . . . . . . \n",
+      "       4 8 3 7 1 6 0 4 9 3 7 2 6 0 5 9 3 8 2 6 1 5 9 4 8 2 7 1 5 \n",
+      "       3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 \n",
       "\n",
       "-------------------------\n",
       "|        Summary        |\n",
@@ -604,11 +614,21 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "generating CLKs: 100%|█| 5.00k/5.00k [00:03<00:00, 1.37kclk/s, mean=837, std=20.5]\n",
-      "\u001b[31mCLK data written to clks_a.json\u001b[0m\n"
+      "\n",
+      "generating CLKs:   0%|          | 0.00/5.00k [00:00<?, ?clk/s, mean=0, std=0]\n",
+      "generating CLKs:   4%|4         | 200/5.00k [00:02<00:53, 89.8clk/s, mean=838, std=20.3]\n",
+      "generating CLKs:  24%|##4       | 1.20k/5.00k [00:02<00:29, 128clk/s, mean=837, std=20.9]\n",
+      "generating CLKs:  32%|###2      | 1.60k/5.00k [00:02<00:19, 178clk/s, mean=837, std=21.2]\n",
+      "generating CLKs:  36%|###6      | 1.80k/5.00k [00:02<00:13, 245clk/s, mean=837, std=20.8]\n",
+      "generating CLKs:  56%|#####6    | 2.80k/5.00k [00:02<00:06, 344clk/s, mean=837, std=20.9]\n",
+      "generating CLKs:  64%|######4   | 3.20k/5.00k [00:03<00:03, 458clk/s, mean=837, std=20.7]\n",
+      "generating CLKs:  80%|########  | 4.00k/5.00k [00:03<00:01, 635clk/s, mean=837, std=20.5]\n",
+      "generating CLKs:  96%|#########6| 4.80k/5.00k [00:03<00:00, 856clk/s, mean=837, std=20.5]\n",
+      "generating CLKs: 100%|##########| 5.00k/5.00k [00:03<00:00, 1.47kclk/s, mean=837, std=20.5]\n",
+      "CLK data written to clks_a.json\n"
      ]
     }
    ],
@@ -724,11 +744,21 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "generating CLKs: 100%|█| 5.00k/5.00k [00:02<00:00, 1.62kclk/s, mean=698, std=23.3]\n",
-      "\u001b[31mCLK data written to clks_a.json\u001b[0m\n"
+      "\n",
+      "generating CLKs:   0%|          | 0.00/5.00k [00:00<?, ?clk/s, mean=0, std=0]\n",
+      "generating CLKs:   4%|4         | 200/5.00k [00:02<01:05, 73.5clk/s, mean=696, std=27.2]\n",
+      "generating CLKs:  20%|##        | 1.00k/5.00k [00:02<00:38, 104clk/s, mean=698, std=23] \n",
+      "generating CLKs:  32%|###2      | 1.60k/5.00k [00:02<00:22, 148clk/s, mean=698, std=24.1]\n",
+      "generating CLKs:  40%|####      | 2.00k/5.00k [00:03<00:14, 208clk/s, mean=698, std=23.9]\n",
+      "generating CLKs:  52%|#####2    | 2.60k/5.00k [00:03<00:08, 290clk/s, mean=698, std=23.8]\n",
+      "generating CLKs:  64%|######4   | 3.20k/5.00k [00:03<00:04, 406clk/s, mean=698, std=23.4]\n",
+      "generating CLKs:  80%|########  | 4.00k/5.00k [00:03<00:01, 565clk/s, mean=698, std=23.2]\n",
+      "generating CLKs:  96%|#########6| 4.80k/5.00k [00:03<00:00, 782clk/s, mean=698, std=23.4]\n",
+      "generating CLKs: 100%|##########| 5.00k/5.00k [00:03<00:00, 1.38kclk/s, mean=698, std=23.3]\n",
+      "CLK data written to clks_a.json\n"
      ]
     }
    ],
@@ -796,11 +826,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "generating CLKs: 100%|█| 5.00k/5.00k [00:02<00:00, 1.72kclk/s, mean=689, std=30.9]\n",
-      "\u001b[31mCLK data written to clks_b.json\u001b[0m\n"
+      "\n",
+      "generating CLKs:   0%|          | 0.00/5.00k [00:00<?, ?clk/s, mean=0, std=0]\n",
+      "generating CLKs:   4%|4         | 200/5.00k [00:02<00:55, 86.0clk/s, mean=688, std=30.2]\n",
+      "generating CLKs:  28%|##8       | 1.40k/5.00k [00:02<00:29, 122clk/s, mean=688, std=31] \n",
+      "generating CLKs:  36%|###6      | 1.80k/5.00k [00:02<00:18, 171clk/s, mean=688, std=31.5]\n",
+      "generating CLKs:  56%|#####6    | 2.80k/5.00k [00:02<00:09, 242clk/s, mean=688, std=31.9]\n",
+      "generating CLKs:  68%|######8   | 3.40k/5.00k [00:02<00:04, 337clk/s, mean=689, std=31.5]\n",
+      "generating CLKs:  96%|#########6| 4.80k/5.00k [00:02<00:00, 476clk/s, mean=689, std=30.7]\n",
+      "generating CLKs: 100%|##########| 5.00k/5.00k [00:03<00:00, 1.60kclk/s, mean=689, std=30.9]\n",
+      "CLK data written to clks_b.json\n"
      ]
     }
    ],
@@ -844,7 +882,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"project_count\": 8237, \"rate\": 2203313, \"status\": \"ok\"}\r\n"
+      "{\"project_count\": 9049, \"rate\": 1756477, \"status\": \"ok\"}\n"
      ]
     }
    ],
@@ -873,10 +911,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[31mProject created\u001b[0m\r\n"
+      "Project created\n"
      ]
     }
    ],
@@ -910,11 +948,11 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"project_id\": \"4770dae729ff23ee210084f737ff4081162150136714b18f\",\n",
-      "    \"result_token\": \"5421e52ba711e3a2f0ef4f51172ec596e56b55375728ff28\",\n",
+      "    \"project_id\": \"1bddaa4ea387af0fc53f6f2f11460c7be4e1dc664be8b9f0\",\n",
+      "    \"result_token\": \"8f7feb1600d44c9bc0107959fba49f8a3583eedd8b3f1e8d\",\n",
       "    \"update_tokens\": [\n",
-      "        \"61b588d2fbcd3b0010d2bffc0b25f941e640e663325f8620\",\n",
-      "        \"4e551e61f67228f9cf503117d29296de1760d967fcc9562b\"\n",
+      "        \"6746745ce79d2184b00fae50f30ab8c555f93beaa3de2a04\",\n",
+      "        \"0a34b5303246736e6c6e375ff63a40584991f0119682ad74\"\n",
       "    ]\n",
       "}\n"
      ]
@@ -984,10 +1022,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[31mEntity Matching Server: https://testing.es.data61.xyz\u001b[0m\r\n"
+      "Entity Matching Server: https://testing.es.data61.xyz\n"
      ]
     }
    ],
@@ -1012,8 +1050,8 @@
      "data": {
       "text/plain": [
        "{'name': 'CLI tutorial run A',\n",
-       " 'notes': 'Run created by clkhash 0.13.0',\n",
-       " 'run_id': '85079b9920d316e9320c422e29c1189e11184ccb052ff7be',\n",
+       " 'notes': 'Run created by clkhash 0.14.0',\n",
+       " 'run_id': 'c2b187b59e7a7428d75d85d9a5fa07396518fde49e955235',\n",
        " 'threshold': 0.9}"
       ]
      },
@@ -1049,17 +1087,17 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[31mState: completed\n",
-      "Stage (3/3): compute output\u001b[0m\n",
-      "\u001b[31mState: completed\n",
-      "Stage (3/3): compute output\u001b[0m\n",
-      "\u001b[31mState: completed\n",
-      "Stage (3/3): compute output\u001b[0m\n",
-      "\u001b[31mDownloading result\u001b[0m\n",
-      "\u001b[31mReceived result\u001b[0m\n"
+      "State: running\n",
+      "Stage (3/3): compute output\n",
+      "State: completed\n",
+      "Stage (3/3): compute output\n",
+      "State: completed\n",
+      "Stage (3/3): compute output\n",
+      "Downloading result\n",
+      "Received result\n"
      ]
     }
    ],
@@ -1201,10 +1239,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[31mEntity Matching Server: https://testing.es.data61.xyz\u001b[0m\r\n"
+      "Entity Matching Server: https://testing.es.data61.xyz\n"
      ]
     }
    ],
@@ -1231,17 +1269,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[31mState: completed\n",
-      "Stage (3/3): compute output\u001b[0m\n",
-      "\u001b[31mState: completed\n",
-      "Stage (3/3): compute output\u001b[0m\n",
-      "\u001b[31mState: completed\n",
-      "Stage (3/3): compute output\u001b[0m\n",
-      "\u001b[31mDownloading result\u001b[0m\n",
-      "\u001b[31mReceived result\u001b[0m\n"
+      "State: running\n",
+      "Stage (2/3): compute similarity scores\n",
+      "State: running\n",
+      "Stage (2/3): compute similarity scores\n",
+      "State: running\n",
+      "Stage (3/3): compute output\n",
+      "State: completed\n",
+      "Stage (3/3): compute output\n",
+      "Downloading result\n",
+      "Received result\n"
      ]
     }
    ],
@@ -1301,10 +1341,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[31mEntity Matching Server: https://testing.es.data61.xyz\u001b[0m\r\n"
+      "Entity Matching Server: https://testing.es.data61.xyz\n"
      ]
     }
    ],
@@ -1331,20 +1371,22 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[31mState: running\n",
-      "Stage (2/3): compute similarity scores\u001b[0m\n",
-      "\u001b[31mState: running\n",
+      "State: running\n",
       "Stage (2/3): compute similarity scores\n",
-      "Progress: 100.00%\u001b[0m\n",
-      "\u001b[31mState: running\n",
-      "Stage (3/3): compute output\u001b[0m\n",
-      "\u001b[31mState: completed\n",
-      "Stage (3/3): compute output\u001b[0m\n",
-      "\u001b[31mDownloading result\u001b[0m\n",
-      "\u001b[31mReceived result\u001b[0m\n"
+      "State: running\n",
+      "Stage (2/3): compute similarity scores\n",
+      "State: running\n",
+      "Stage (2/3): compute similarity scores\n",
+      "Progress: 100.00%\n",
+      "State: running\n",
+      "Stage (3/3): compute output\n",
+      "State: completed\n",
+      "Stage (3/3): compute output\n",
+      "Downloading result\n",
+      "Received result\n"
      ]
     }
    ],
@@ -1406,10 +1448,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[31mRun deleted\u001b[0m\r\n"
+      "Run deleted\n"
      ]
     }
    ],
@@ -1427,10 +1469,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[31mProject deleted\u001b[0m\r\n"
+      "Project deleted\n"
      ]
     }
    ],
@@ -1458,7 +1500,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.0"
   },
   "pycharm": {
    "stem_cell": {

--- a/docs/tutorial_cli.ipynb
+++ b/docs/tutorial_cli.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,13 +55,160 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>given_name</th>\n",
+       "      <th>surname</th>\n",
+       "      <th>street_number</th>\n",
+       "      <th>address_1</th>\n",
+       "      <th>address_2</th>\n",
+       "      <th>suburb</th>\n",
+       "      <th>postcode</th>\n",
+       "      <th>state</th>\n",
+       "      <th>date_of_birth</th>\n",
+       "      <th>soc_sec_id</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rec_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>rec-1070-org</th>\n",
+       "      <td>michaela</td>\n",
+       "      <td>neumann</td>\n",
+       "      <td>8</td>\n",
+       "      <td>stanley street</td>\n",
+       "      <td>miami</td>\n",
+       "      <td>winston hills</td>\n",
+       "      <td>4223</td>\n",
+       "      <td>nsw</td>\n",
+       "      <td>19151111</td>\n",
+       "      <td>5304218</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rec-1016-org</th>\n",
+       "      <td>courtney</td>\n",
+       "      <td>painter</td>\n",
+       "      <td>12</td>\n",
+       "      <td>pinkerton circuit</td>\n",
+       "      <td>bega flats</td>\n",
+       "      <td>richlands</td>\n",
+       "      <td>4560</td>\n",
+       "      <td>vic</td>\n",
+       "      <td>19161214</td>\n",
+       "      <td>4066625</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rec-4405-org</th>\n",
+       "      <td>charles</td>\n",
+       "      <td>green</td>\n",
+       "      <td>38</td>\n",
+       "      <td>salkauskas crescent</td>\n",
+       "      <td>kela</td>\n",
+       "      <td>dapto</td>\n",
+       "      <td>4566</td>\n",
+       "      <td>nsw</td>\n",
+       "      <td>19480930</td>\n",
+       "      <td>4365168</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rec-1288-org</th>\n",
+       "      <td>vanessa</td>\n",
+       "      <td>parr</td>\n",
+       "      <td>905</td>\n",
+       "      <td>macquoid place</td>\n",
+       "      <td>broadbridge manor</td>\n",
+       "      <td>south grafton</td>\n",
+       "      <td>2135</td>\n",
+       "      <td>sa</td>\n",
+       "      <td>19951119</td>\n",
+       "      <td>9239102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rec-3585-org</th>\n",
+       "      <td>mikayla</td>\n",
+       "      <td>malloney</td>\n",
+       "      <td>37</td>\n",
+       "      <td>randwick road</td>\n",
+       "      <td>avalind</td>\n",
+       "      <td>hoppers crossing</td>\n",
+       "      <td>4552</td>\n",
+       "      <td>vic</td>\n",
+       "      <td>19860208</td>\n",
+       "      <td>7207688</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             given_name   surname street_number            address_1  \\\n",
+       "rec_id                                                                 \n",
+       "rec-1070-org   michaela   neumann             8       stanley street   \n",
+       "rec-1016-org   courtney   painter            12    pinkerton circuit   \n",
+       "rec-4405-org    charles     green            38  salkauskas crescent   \n",
+       "rec-1288-org    vanessa      parr           905       macquoid place   \n",
+       "rec-3585-org    mikayla  malloney            37        randwick road   \n",
+       "\n",
+       "                      address_2            suburb postcode state  \\\n",
+       "rec_id                                                             \n",
+       "rec-1070-org              miami     winston hills     4223   nsw   \n",
+       "rec-1016-org         bega flats         richlands     4560   vic   \n",
+       "rec-4405-org               kela             dapto     4566   nsw   \n",
+       "rec-1288-org  broadbridge manor     south grafton     2135    sa   \n",
+       "rec-3585-org            avalind  hoppers crossing     4552   vic   \n",
+       "\n",
+       "             date_of_birth soc_sec_id  \n",
+       "rec_id                                 \n",
+       "rec-1070-org      19151111    5304218  \n",
+       "rec-1016-org      19161214    4066625  \n",
+       "rec-4405-org      19480930    4365168  \n",
+       "rec-1288-org      19951119    9239102  \n",
+       "rec-3585-org      19860208    7207688  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dfA, dfB = load_febrl4()\n",
     "\n",
@@ -79,20 +226,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['given_name', 'surname', 'street_number', 'address_1', 'address_2',\n",
+       "       'suburb', 'postcode', 'state', 'date_of_birth', 'soc_sec_id'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dfA.columns"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -117,13 +277,89 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"version\": 2,\n",
+      "  \"clkConfig\": {\n",
+      "    \"l\": 1024,\n",
+      "    \"kdf\": {\n",
+      "      \"type\": \"HKDF\",\n",
+      "      \"hash\": \"SHA256\",\n",
+      "        \"info\": \"c2NoZW1hX2V4YW1wbGU=\",\n",
+      "        \"salt\": \"SCbL2zHNnmsckfzchsNkZY9XoHk96P/G5nUBrM7ybymlEFsMV6PAeDZCNp3rfNUPCtLDMOGQHG4pCQpfhiHCyA==\",\n",
+      "        \"keySize\": 64\n",
+      "    }\n",
+      "  },\n",
+      "  \"features\": [\n",
+      "    {\n",
+      "      \"identifier\": \"rec_id\",\n",
+      "      \"ignored\": true\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"given_name\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\", \"maxLength\": 64 },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\": 300}, \"hash\": {\"type\": \"doubleHash\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"surname\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\", \"maxLength\": 64 },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\": 300}, \"hash\": {\"type\": \"doubleHash\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"street_number\",\n",
+      "      \"format\": { \"type\": \"integer\" },\n",
+      "      \"hashing\": { \"ngram\": 1, \"positional\": true, \"strategy\": {\"numBits\": 300}, \"missingValue\": {\"sentinel\": \"\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"address_1\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\" },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\":  300} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"address_2\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\" },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\":  300} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"suburb\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\" },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\":  300} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"postcode\",\n",
+      "      \"format\": { \"type\": \"integer\", \"minimum\": 100, \"maximum\": 9999 },\n",
+      "      \"hashing\": { \"ngram\": 1, \"positional\": true, \"strategy\": {\"numBits\":  300} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"state\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\", \"maxLength\": 3 },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\": 300} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"date_of_birth\",\n",
+      "      \"format\": { \"type\": \"integer\" },\n",
+      "      \"hashing\": { \"ngram\": 1, \"positional\": true, \"strategy\": {\"numBits\":  300}, \"missingValue\": {\"sentinel\": \"\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"soc_sec_id\",\n",
+      "      \"ignored\": true\n",
+      "    }\n",
+      "  ]\n",
+      "}\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "with open(\"_static/febrl_schema_v2_overweight.json\") as f:\n",
     "    print(f.read())"
@@ -142,11 +378,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mschema is valid\u001b[0m\r\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil validate-schema _static/febrl_schema_v2_overweight.json"
    ]
@@ -164,13 +408,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "generating CLKs: 100%|█| 5.00k/5.00k [00:03<00:00, 1.07kclk/s, mean=945, std=14.2]\n",
+      "\u001b[31mCLK data written to clks_a.json\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil hash PII_a.csv key1 key2 _static/febrl_schema_v2_overweight.json clks_a.json"
    ]
@@ -190,9 +443,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    --------------------------------------------------------------------------------------------------------------------------\n",
+      "    |                                                       popcounts                                                        |\n",
+      "    --------------------------------------------------------------------------------------------------------------------------\n",
+      "\n",
+      " 617| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 585| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 552| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 520| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 487| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 455| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 422| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 390| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 357| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 325| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 293| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 260| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 228| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 195| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 163| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      " 130| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      "  98| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      "  65| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      "  33| \u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\n",
+      "   1| \u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39m \u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\u001b[39mo\u001b[39m\n",
+      "     ------------------------------------------------------------\n",
+      "\u001b[39m     \u001b[39m8 8 8 8 8 8 8 8 8 8 8 8 8 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 \n",
+      "\u001b[39m     \u001b[39m4 5 5 5 6 6 7 7 8 8 9 9 9 0 0 1 1 2 2 3 3 3 4 4 5 5 6 6 7 7 \n",
+      "\u001b[39m     \u001b[39m6 0 4 9 3 8 2 7 1 5 0 4 9 3 8 2 6 1 5 0 4 9 3 7 2 6 1 5 0 4 \n",
+      "\u001b[39m     \u001b[39m  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . \n",
+      "\u001b[39m     \u001b[39m  4 8 3 7 1 6 0 4 9 3 7 2 6 0 5 9 3 8 2 6 1 5 9 4 8 2 7 1 5 \n",
+      "\u001b[39m     \u001b[39m  3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 0 3 6 \n",
+      "\n",
+      "-------------------------\n",
+      "|        Summary        |\n",
+      "-------------------------\n",
+      "|   observations: 5000  |\n",
+      "| min value: 846.000000 |\n",
+      "|   mean : 944.711200   |\n",
+      "| max value: 979.000000 |\n",
+      "-------------------------\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil describe clks_a.json"
    ]
@@ -208,11 +508,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"version\": 2,\n",
+      "  \"clkConfig\": {\n",
+      "    \"l\": 1024,\n",
+      "    \"kdf\": {\n",
+      "      \"type\": \"HKDF\",\n",
+      "      \"hash\": \"SHA256\",\n",
+      "        \"info\": \"c2NoZW1hX2V4YW1wbGU=\",\n",
+      "        \"salt\": \"SCbL2zHNnmsckfzchsNkZY9XoHk96P/G5nUBrM7ybymlEFsMV6PAeDZCNp3rfNUPCtLDMOGQHG4pCQpfhiHCyA==\",\n",
+      "        \"keySize\": 64\n",
+      "    }\n",
+      "  },\n",
+      "  \"features\": [\n",
+      "    {\n",
+      "      \"identifier\": \"rec_id\",\n",
+      "      \"ignored\": true\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"given_name\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\", \"maxLength\": 64 },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\": 200}, \"hash\": {\"type\": \"doubleHash\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"surname\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\", \"maxLength\": 64 },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\": 200}, \"hash\": {\"type\": \"doubleHash\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"street_number\",\n",
+      "      \"format\": { \"type\": \"integer\" },\n",
+      "      \"hashing\": { \"ngram\": 1, \"positional\": true, \"strategy\": {\"numBits\": 200}, \"missingValue\": {\"sentinel\": \"\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"address_1\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\" },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\":  200} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"address_2\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\" },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\":  200} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"suburb\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\" },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\":  200} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"postcode\",\n",
+      "      \"format\": { \"type\": \"integer\", \"minimum\": 100, \"maximum\": 9999 },\n",
+      "      \"hashing\": { \"ngram\": 1, \"positional\": true, \"strategy\": {\"numBits\":  200} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"state\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\", \"maxLength\": 3 },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\": 200} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"date_of_birth\",\n",
+      "      \"format\": { \"type\": \"integer\" },\n",
+      "      \"hashing\": { \"ngram\": 1, \"positional\": true, \"strategy\": {\"numBits\":  200}, \"missingValue\": {\"sentinel\": \"\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"soc_sec_id\",\n",
+      "      \"ignored\": true\n",
+      "    }\n",
+      "  ]\n",
+      "}\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "with open(\"_static/febrl_schema_v2_reduced.json\") as f:\n",
     "    print(f.read())"
@@ -220,13 +596,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "generating CLKs: 100%|█| 5.00k/5.00k [00:03<00:00, 1.37kclk/s, mean=837, std=20.5]\n",
+      "\u001b[31mCLK data written to clks_a.json\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil hash PII_a.csv key1 key2 _static/febrl_schema_v2_reduced.json clks_a.json"
    ]
@@ -242,13 +627,90 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"version\": 2,\n",
+      "  \"clkConfig\": {\n",
+      "    \"l\": 1024,\n",
+      "    \"kdf\": {\n",
+      "      \"type\": \"HKDF\",\n",
+      "      \"hash\": \"SHA256\",\n",
+      "        \"info\": \"c2NoZW1hX2V4YW1wbGU=\",\n",
+      "        \"salt\": \"SCbL2zHNnmsckfzchsNkZY9XoHk96P/G5nUBrM7ybymlEFsMV6PAeDZCNp3rfNUPCtLDMOGQHG4pCQpfhiHCyA==\",\n",
+      "        \"keySize\": 64\n",
+      "    }\n",
+      "  },\n",
+      "  \"features\": [\n",
+      "    {\n",
+      "      \"identifier\": \"rec_id\",\n",
+      "      \"ignored\": true\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"given_name\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\", \"maxLength\": 64 },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\": 200}, \"hash\": {\"type\": \"doubleHash\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"surname\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\", \"maxLength\": 64 },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\": 200}, \"hash\": {\"type\": \"doubleHash\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"street_number\",\n",
+      "      \"format\": { \"type\": \"integer\" },\n",
+      "      \"hashing\": { \"ngram\": 1, \"positional\": true, \"strategy\": {\"numBits\": 100}, \"missingValue\": {\"sentinel\": \"\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"address_1\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\" },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\":  100} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"address_2\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\" },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\":  100} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"suburb\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\": \"utf-8\" },\n",
+      "      \"hashing\": { \"ngram\": 2, \"strategy\": {\"numBits\":  100} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"postcode\",\n",
+      "      \"format\": { \"type\": \"integer\", \"minimum\": 50, \"maximum\": 9999 },\n",
+      "      \"hashing\": { \"ngram\": 1, \"positional\": true, \"strategy\": {\"numBits\":  100} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"state\",\n",
+      "      \"format\": { \"type\": \"string\", \"encoding\":  \"utf-8\"},\n",
+      "      \"hashing\": {\"ngram\": 2, \"positional\": true, \"strategy\": {\"numBits\": 100}, \"missingValue\": {\"sentinel\":  \"\"}\n",
+      "      }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"date_of_birth\",\n",
+      "      \"format\": { \"type\": \"integer\" },\n",
+      "      \"hashing\": { \"ngram\": 1, \"positional\": true, \"strategy\": {\"numBits\":  200}, \"missingValue\": {\"sentinel\": \"\"} }\n",
+      "    },\n",
+      "    {\n",
+      "      \"identifier\": \"soc_sec_id\",\n",
+      "      \"ignored\": true\n",
+      "    }\n",
+      "  ]\n",
+      "}\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "with open(\"_static/febrl_schema_v2_final.json\") as f:\n",
     "    print(f.read())"
@@ -256,11 +718,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "generating CLKs: 100%|█| 5.00k/5.00k [00:02<00:00, 1.62kclk/s, mean=698, std=23.3]\n",
+      "\u001b[31mCLK data written to clks_a.json\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil hash PII_a.csv key1 key2 _static/febrl_schema_v2_final.json clks_a.json"
    ]
@@ -278,13 +749,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'unsZ/W7D35s8q759bf77155ean+p8fq96fzf9u9bnXf3rX2gGfntPvR2/tOd314aOvuv/97z+lrY8st+fP8PYVd9/KjZN6rMx+T/O6r/v/Hdvt1f1at2+f+Xe53iX94f9988b3mhTsIQbf+7Xr3Sff71fuze9k3sX++db4d73v0='"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# If you have jq tool installed:\n",
     "#!jq .clks[0] clks_a.json\n",
@@ -306,13 +788,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "generating CLKs: 100%|█| 5.00k/5.00k [00:02<00:00, 1.72kclk/s, mean=689, std=30.9]\n",
+      "\u001b[31mCLK data written to clks_b.json\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "dfB.to_csv('PII_b.csv')\n",
     "\n",
@@ -342,13 +833,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"project_count\": 8237, \"rate\": 2203313, \"status\": \"ok\"}\r\n"
+     ]
+    }
+   ],
    "source": [
     "SERVER = 'https://testing.es.data61.xyz'\n",
     "\n",
@@ -366,13 +865,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mProject created\u001b[0m\r\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil create-project --server={SERVER} --schema _static/febrl_schema_v2_final.json --output credentials.json --type \"mapping\" --name \"tutorial\""
    ]
@@ -391,13 +898,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "pycharm": {
      "is_executing": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"project_id\": \"4770dae729ff23ee210084f737ff4081162150136714b18f\",\n",
+      "    \"result_token\": \"5421e52ba711e3a2f0ef4f51172ec596e56b55375728ff28\",\n",
+      "    \"update_tokens\": [\n",
+      "        \"61b588d2fbcd3b0010d2bffc0b25f941e640e663325f8620\",\n",
+      "        \"4e551e61f67228f9cf503117d29296de1760d967fcc9562b\"\n",
+      "    ]\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "credentials = json.load(open('credentials.json', 'rt'))\n",
     "print(json.dumps(credentials, indent=4))"
@@ -415,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -433,7 +955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,11 +978,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mEntity Matching Server: https://testing.es.data61.xyz\u001b[0m\r\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil create --verbose  \\\n",
     "    --server=\"{SERVER}\" \\\n",
@@ -473,11 +1003,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': 'CLI tutorial run A',\n",
+       " 'notes': 'Run created by clkhash 0.13.0',\n",
+       " 'run_id': '85079b9920d316e9320c422e29c1189e11184ccb052ff7be',\n",
+       " 'threshold': 0.9}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "run_info = json.load(open('run_info.json', 'rt'))\n",
     "run_info"
@@ -496,14 +1040,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {
     "pycharm": {},
     "tags": [
      "nbval-ignore-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mState: completed\n",
+      "Stage (3/3): compute output\u001b[0m\n",
+      "\u001b[31mState: completed\n",
+      "Stage (3/3): compute output\u001b[0m\n",
+      "\u001b[31mState: completed\n",
+      "Stage (3/3): compute output\u001b[0m\n",
+      "\u001b[31mDownloading result\u001b[0m\n",
+      "\u001b[31mReceived result\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil results --watch \\\n",
     "        --project=\"{credentials['project_id']}\" \\\n",
@@ -515,11 +1074,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The service linked 4061 entities.\n"
+     ]
+    }
+   ],
    "source": [
     "with open('results.txt') as f:\n",
     "    str_mapping = json.load(f)['mapping']\n",
@@ -539,7 +1106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "pycharm": {}
    },
@@ -586,11 +1153,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "idx_a, idx_b,     rec_id_a,       rec_id_b\n",
+      "---------------------------------------------\n",
+      "  2,   2751,    rec-1016-org,  rec-1016-dup-0\n",
+      "  3,   4657,    rec-4405-org,  rec-4405-dup-0\n",
+      "  4,   4120,    rec-1288-org,  rec-1288-dup-0\n",
+      "  5,   3307,    rec-3585-org,  rec-3585-dup-0\n",
+      "  6,   2306,     rec-298-org,   rec-298-dup-0\n",
+      "  7,   3945,    rec-1985-org,  rec-1985-dup-0\n",
+      "  8,    993,    rec-2404-org,  rec-2404-dup-0\n",
+      "  9,   4613,    rec-1473-org,  rec-1473-dup-0\n",
+      " 10,   3630,     rec-453-org,   rec-453-dup-0\n",
+      "---------------------------------------------\n",
+      "Precision: 1.00, Recall: 0.81, Accuracy: 0.81\n"
+     ]
+    }
+   ],
    "source": [
     "describe_accuracy(mapping, True)"
    ]
@@ -601,18 +1188,26 @@
     "pycharm": {}
    },
    "source": [
-    "Precision tells us about how many of the found matches are actual matches. The score of 1.0 means that we did perfectly in this respect, however, **recall**, the measure of how many of the actual matches were correctly identified, is quite low with only 80%.\n",
+    "Precision tells us about how many of the found matches are actual matches. The score of 1.0 means that we did perfectly in this respect, however, **recall**, the measure of how many of the actual matches were correctly identified, is quite low with only 81%.\n",
     "\n",
     "Let's go back and create another mapping with a `threshold` value of `0.8`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mEntity Matching Server: https://testing.es.data61.xyz\u001b[0m\r\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil create --verbose  \\\n",
     "    --server=\"{SERVER}\" \\\n",
@@ -627,14 +1222,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {
     "pycharm": {},
     "tags": [
      "nbval-ignore-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mState: completed\n",
+      "Stage (3/3): compute output\u001b[0m\n",
+      "\u001b[31mState: completed\n",
+      "Stage (3/3): compute output\u001b[0m\n",
+      "\u001b[31mState: completed\n",
+      "Stage (3/3): compute output\u001b[0m\n",
+      "\u001b[31mDownloading result\u001b[0m\n",
+      "\u001b[31mReceived result\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil results --watch \\\n",
     "        --project=\"{credentials['project_id']}\" \\\n",
@@ -646,11 +1256,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The service linked 4967 entities.\n",
+      "Precision: 1.00, Recall: 0.99, Accuracy: 0.99\n"
+     ]
+    }
+   ],
    "source": [
     "with open('results.txt') as f:\n",
     "    str_mapping = json.load(f)['mapping']\n",
@@ -671,21 +1290,29 @@
     "\n",
     "The explanation is that when the information about an entity differs slightly in the two datasets (e.g. spelling errors, abbrevations, missing values, ...) then the corresponding CLKs will differ in some number of bits as well. For the datasets in this tutorial the perturbations are such that only 80% of the derived CLK pairs overlap more than 90% (the first threshold). Whereas 99% of all matching pairs overlap more than 80%.\n",
     "\n",
-    "If we keep reducing the threshold value, then we will start to observe mistakes in the found matches -- the precision decreases (if an entry in dataset A has no match in dataset B, but we keep reducing the threshold, eventually a comparison with an entry in B will be above the threshold leading to a false match). But at the same time the recall value will keep increasing for a while, as a lower threshold allows for more of the actual matches to be found. However, as our example dataset only contains matches (every entry in A has a match in B), this phenomenon cannot be observered. With the threshold `0.75` we identify all matches correctly (at the cost of a longer execution time)."
+    "If we keep reducing the threshold value, then we will start to observe mistakes in the found matches -- the precision decreases (if an entry in dataset A has no match in dataset B, but we keep reducing the threshold, eventually a comparison with an entry in B will be above the threshold leading to a false match). But at the same time the recall value will keep increasing for a while, as a lower threshold allows for more of the actual matches to be found. However, as our example dataset only contains matches (every entry in A has a match in B), this phenomenon cannot be observered. With the threshold `0.72` we identify all matches but one correctly (at the cost of a longer execution time)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mEntity Matching Server: https://testing.es.data61.xyz\u001b[0m\r\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil create --verbose  \\\n",
     "    --server=\"{SERVER}\" \\\n",
     "    --output \"run_info.json\" \\\n",
-    "    --threshold=0.75 \\\n",
+    "    --threshold=0.72 \\\n",
     "    --project=\"{credentials['project_id']}\" \\\n",
     "    --apikey=\"{credentials['result_token']}\" \\\n",
     "    --name=\"CLI tutorial run B\"\n",
@@ -695,14 +1322,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {
     "pycharm": {},
     "tags": [
      "nbval-ignore-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mState: running\n",
+      "Stage (2/3): compute similarity scores\u001b[0m\n",
+      "\u001b[31mState: running\n",
+      "Stage (2/3): compute similarity scores\n",
+      "Progress: 100.00%\u001b[0m\n",
+      "\u001b[31mState: running\n",
+      "Stage (3/3): compute output\u001b[0m\n",
+      "\u001b[31mState: completed\n",
+      "Stage (3/3): compute output\u001b[0m\n",
+      "\u001b[31mDownloading result\u001b[0m\n",
+      "\u001b[31mReceived result\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!clkutil results --watch \\\n",
     "        --project=\"{credentials['project_id']}\" \\\n",
@@ -714,11 +1359,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The service linked 4999 entities.\n",
+      "Precision: 1.00, Recall: 1.00, Accuracy: 1.00\n"
+     ]
+    }
+   ],
    "source": [
     "with open('results.txt') as f:\n",
     "    str_mapping = json.load(f)['mapping']\n",
@@ -746,11 +1400,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {
     "pycharm": {}
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mRun deleted\u001b[0m\r\n"
+     ]
+    }
+   ],
    "source": [
     "# Deleting a run\n",
     "!clkutil delete --project=\"{credentials['project_id']}\" \\\n",
@@ -761,9 +1423,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mProject deleted\u001b[0m\r\n"
+     ]
+    }
+   ],
    "source": [
     "# Deleting a project\n",
     "!clkutil delete-project --project=\"{credentials['project_id']}\" \\\n",
@@ -788,7 +1458,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.3"
   },
   "pycharm": {
    "stem_cell": {

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ else:
 
 setup(
     name="clkhash",
-    version='0.13.1-b6',
+    version='0.14.0',
     description='Encoding utility to create Cryptographic Linkage Keys',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -74,3 +74,8 @@ class TestTokenizer(unittest.TestCase):
 
     def test_dummy(self):
         self.assertEqual(list(dummy('jobs')), [])
+
+    def test_empty_input(self):
+        self.assertEqual(list(p1_20("")), [])
+        self.assertEqual(list(p1_20_true("")), [])
+        self.assertEqual(list(p2_20("")), [])


### PR DESCRIPTION
There is a bug in the tokenizer.

If a feature is encoded as bi-grams and a value happens to be empty, then the tokenizer would return a token of two white-spaces. However, the correct behavior would be to return nothing.

This is especially bad for the *variable-k* encoding scheme:
A missing value, as it will be tokenized into a "  " token, would be encoded with *numBits* bits. Thus all entities with missing values for that feature will have all those bits in common and in turn an inflated similarity score. This screws up the matching pretty badly!