### PR TITLE
Switch to using a fork of bitarray that distributes binary wheels.

### DIFF
--- a/.azurePipeline/wholeBuild.yml
+++ b/.azurePipeline/wholeBuild.yml
@@ -6,6 +6,7 @@ parameters:
 jobs:
 - job: 'test_and_publish'
   strategy:
+    maxParallel: 2
     matrix:
       ${{ each py in parameters.pythonVersions }}:
         ${{ each os in parameters.operatingSystems }}:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## 0.14.0 (in development)
 
 - Fix bug where empty inputs don't generate tokens.
-- CLI commands to delete runs and projects.
-- Migrate to Azure DevOps for CI testing.
-- Synthetic data generation using distributions.
-- Switch to using a fork of `bitarray` that distributes binary wheels so installing clkhash doesn't require a compiler.
+- CLI commands to delete runs and projects. #265
+- Migrate to Azure DevOps for CI testing. #262
+- Synthetic data generation using distributions. #271, #275
+- Switch to using a fork of `bitarray` that distributes binary wheels. This means installing clkhash no longer 
+  requires a c compiler. #308
 
 ### Breaking Changes
 
-- The cli method `hash` requires only one secret instead of two.
+- The cli method `hash` requires only one secret instead of two. #303
 - The clks generated with `clkhash` <= 0.14.0 are not compatible with clks from version 0.14.0 onwards.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 ## 0.14.0 (in development)
 
 - Fix bug where empty inputs don't generate tokens.
-- CLI commands to delete runs nad projects.
+- CLI commands to delete runs and projects.
 - Migrate to Azure DevOps for CI testing.
 - Synthetic data generation using distributions.
+- Switch to using a fork of `bitarray` that distributes binary wheels so installing clkhash doesn't require a compiler.
 
-BREAKING CHANGE:
+### Breaking Changes
 
 - The cli method `hash` requires only one secret instead of two.
-- The clks pre 0.14 are not compatible with clks from version 0.14.0
+- The clks generated with `clkhash` <= 0.14.0 are not compatible with clks from version 0.14.0 onwards.
+
 
 ## 0.13.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bashplotlib==0.6.5
-bitarray==0.9.3
+bitarray-hardbyte==1.1.0
 click==7.0
 cryptography==2.7
 enum34==1.1.6; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if sys.version_info[0] < 3:
 
 requirements = [
         "bashplotlib>=0.6.5",
-        "bitarray>=0.8",
+        "bitarray-hardbyte>=1.0.0",             # Fork of bitarray distributing binary wheels #153
         "click>=6.7",
         "cryptography>=2.3",
         "enum34==1.1.6; python_version < '3.4'",
@@ -33,7 +33,7 @@ else:
 
 setup(
     name="clkhash",
-    version='0.14.0',
+    version='0.14.0-dev',
     description='Encoding utility to create Cryptographic Linkage Keys',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This change means users no longer require a C compiler to install clkhash.

While waiting to see whether the upstream `bitarray` library will distribute binary wheels (in https://github.com/ilanschnell/bitarray/pull/76) this PR switches to my fork which publishes binary wheels for each platform from a CI. See also issue #153 

https://pypi.org/project/bitarray-hardbyte/

🤡 