### PR TITLE
Add a condition before running the Publish task.

### DIFF
--- a/.azurePipeline/wholeBuild.yml
+++ b/.azurePipeline/wholeBuild.yml
@@ -110,4 +110,4 @@ jobs:
     inputs:
       path: 'dist'
       artifact: '$(pythonVersion)-$(architecture)'
-    condition: and(eq(variables['operatingSystem'], 'vs2017-win2016'), eq(variables['pythonVersion'], '3.7'))
+    condition: and(succeeded(), eq(variables['operatingSystem'], 'vs2017-win2016'), eq(variables['pythonVersion'], '3.7'))


### PR DESCRIPTION
The build https://dev.azure.com/data61/Anonlink/_build/results?buildId=755&view=results shows a surprising behavior:
in the stage `build and test`, on the first attempt, the job "Test with pytest" fails, but its publishing step still ran, because of which re-running the failed jobs fails as the PublishArtifact step cannot overwrite artifacts.

I thought we could do as in the entity-service, i.e. creating a new artifact including the attempt number, but it works in the entity-service because the artifact is not consumed by another job, so its name become irrelevant. Here we need to know its name to be used in the `package` stage.

If we were creating a new artifact for each attemot, we would need to provide the new name to the package stage. To do this, my only thought would be to use environment variables, but it is not available between stages (it only allows it between jobs in the same stage https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-multi-job-output-variable and https://stackoverflow.com/questions/57485621/share-variables-across-stages-in-azure-devops-pipelines)

So the solution in this PR (without guarantee that it will work in all cases, for example it will fail if we re-run the jobs which have succeeded), is simply to ensure that the step is not ran if something fail before.