### PR TITLE
tokenizer of some comparison functions cannot handle missing values properly

### DIFF
--- a/clkhash/comparators.py
+++ b/clkhash/comparators.py
@@ -90,7 +90,10 @@ class ExactComparison(AbstractComparison):
     """
 
     def tokenize(self, word):  # type: (Text) -> Iterable[Text]
-        return word,
+        if len(word) == 0:
+            return tuple()
+        else:
+            return word,
 
 
 class NumericComparison(AbstractComparison):
@@ -159,6 +162,8 @@ class NumericComparison(AbstractComparison):
         self.fractional_precision = fractional_precision
 
     def tokenize(self, word):  # type: (Text) -> Iterable[Text]
+        if len(word) == 0:
+            return tuple()
         try:
             v = int(word, base=10)  # we try int first, so we don't loose precision
             if self.fractional_precision > 0:

--- a/tests/test_comparators.py
+++ b/tests/test_comparators.py
@@ -88,6 +88,10 @@ def test_exact_num_tokens(word):
     assert len(list(ExactComparison().tokenize(word))) == 1
 
 
+def test_exact_empty_input():
+    assert list(ExactComparison().tokenize("")) == []
+
+
 #####
 # testing numeric comparison
 #####
@@ -111,6 +115,7 @@ def test_numeric_exceptions():
 def test_numeric_mix_int_and_floats():
     comp = NumericComparison(1, 20, 3)
     assert comp.tokenize('42') == comp.tokenize('42.000')
+
 
 # we restrict the exponents of the floats such that exponent of number + precision < 308. Otherwise we might get
 # infinity during the tokenization process.
@@ -222,6 +227,11 @@ def test_numeric_overlaps_with_integers(thresh_dist, resolution, candidate):
     assert all(x >= y for x, y in zip(overlaps, overlaps[1:])), 'with increasing distance, the overlap reduces'
 
 
+def test_numeric_empty_input():
+    comp = NumericComparison(1, 20, 3)
+    assert list(comp.tokenize('')) == []
+
+
 #####
 # testing invalid comparison
 #####
@@ -230,3 +240,5 @@ def test_numeric_overlaps_with_integers(thresh_dist, resolution, candidate):
 def test_invalid_comparison():
     with pytest.raises(ValueError):
         comparators.get_comparator({"type": "apples_and_oranges"})
+
+

--- a/tests/test_comparators.py
+++ b/tests/test_comparators.py
@@ -85,7 +85,7 @@ def test_exact_uniqueness(word1, word2):
 
 @given(word=text())
 def test_exact_num_tokens(word):
-    assert len(list(ExactComparison().tokenize(word))) == 1
+    assert len(list(ExactComparison().tokenize(word))) == (1 if len(word) > 0 else 0)
 
 
 def test_exact_empty_input():


### PR DESCRIPTION
The exact comparison and the numeric comparison didn't handle missing values properly.

missing values are delivered as an empty string to the tokenizer, the expected output would be an empty tuple.

This PR implements this functionality and tests for correctness.

closes #322