### PR TITLE
more generous timeout and multiparty upload tests waits properly

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ from clkhash.rest_client import ServiceError, RestClient
 
 from tests import *
 
-ES_TIMEOUT = os.environ.get("ES_TIMEOUT", 20)
+ES_TIMEOUT = os.environ.get("ES_TIMEOUT", 60)
 
 
 class CLITestHelper(unittest.TestCase):
@@ -854,8 +854,10 @@ class TestCliInteractionWithService(CLITestHelper):
 
         self.assertIn('receipt_token', charlie_upload)
 
-        # Give the server a small amount of time to process
-        time.sleep(10.0)
+        self.rest_client.wait_for_run(project['project_id'],
+                                      run['run_id'],
+                                      project['result_token'],
+                                      timeout=ES_TIMEOUT)
 
         results = get_coord_results()
         res = json.loads(results)


### PR DESCRIPTION
same changes as in anonlink-client, 
- the timeout for the entity service interaction is now set to 60 sec, up from 20.
- the multiparty upload test now uses the proper wait function from the rest client.