### PR TITLE
Allow ThreadPoolExecutor for use in AWS Lambda functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ nosetests.xml
 
 # Operating system stuff
 .DS_Store
+
+# Hypothesis
+.hypothesis/
+
+# Docs build
+docs/_build/

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -2,11 +2,11 @@
 Generate CLK from data.
 """
 
-import concurrent.futures
+from concurrent.futures import (ProcessPoolExecutor, ThreadPoolExecutor)
 import logging
 import time
 from typing import (AnyStr, Callable, cast, Iterable, List, Optional,
-                    Sequence, TextIO, Tuple, TypeVar, Union)
+                    Sequence, TextIO, Tuple, TypeVar, Union, Type)
 from future.builtins import range
 from tqdm import tqdm
 
@@ -165,11 +165,8 @@ def generate_clks(pii_data,  # type: Sequence[Sequence[str]]
     futures = []
 
     # Compute Bloom filter from the chunks and then serialise it
-
-    if use_multiprocessing:
-        pool_executor = concurrent.futures.ProcessPoolExecutor
-    else:
-        pool_executor = concurrent.futures.ThreadPoolExecutor
+    pool_executor = ProcessPoolExecutor if use_multiprocessing else \
+        ThreadPoolExecutor # type: Union[Type[ProcessPoolExecutor], Type[ThreadPoolExecutor]]
 
     with pool_executor() as executor:
         for chunk in chunks(pii_data, chunk_size):

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -187,7 +187,7 @@ A corresponding hashing schema can be generated as well::
             "weight": 0
           }
         },
-        {s
+        {
             "minLength": 3
           },
           "hashing": {

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -188,6 +188,11 @@ A corresponding hashing schema can be generated as well::
           }
         },
         {
+          "identifier": "NAME freetext",
+          "format": {
+            "type": "string",
+            "encoding": "utf-8",
+            "case": "mixed",
             "minLength": 3
           },
           "hashing": {
@@ -221,6 +226,7 @@ A corresponding hashing schema can be generated as well::
         }
       ]
     }
+
 
 
 Benchmark

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,7 +1,7 @@
 anonlink>=0.12
-ipython==7.5.0
+ipython==7.12.0
 jupyter
-matplotlib==3.1.1
+matplotlib==3.1.3
 nbsphinx>=0.3
 numpy
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bashplotlib==0.6.5
-bitarray-hardbyte==1.1.0
+bitarray-hardbyte==1.2.2
 click==7.0
 cryptography==2.8
 enum34==1.1.6; python_version < '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ mypy_extensions==0.4.1
 nbval==0.9.1
 pyblake2==1.1.2; python_version < '3.6'
 pyinstaller==3.6
-pytest==4.6.3
+pytest==4.6.9
 pytest-cov==2.7.1
 requests==2.22.0
 requests-mock==1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ requests==2.22.0
 requests-mock==1.6.0
 retrying>=1.3
 six==1.12.0
-tqdm==4.32.2
+tqdm==4.42.1
 typing>=3.6.2; python_version < '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ requests==2.22.0
 requests-mock==1.7.0
 retrying>=1.3
 six==1.14.0
-tqdm==4.42.1
+tqdm==4.43.0
 typing>=3.6.2; python_version < '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,19 +3,19 @@ bitarray-hardbyte==1.2.2
 click==7.0
 cryptography==2.8
 enum34==1.1.6; python_version < '3.4'
-future==0.17.1
-futures==3.2.0; python_version < '3.2'
-jsonschema==3.0.2
-hypothesis==4.32.2
-mypy_extensions==0.4.1
+future==0.18.2
+futures==3.3.0; python_version < '3.2'
+jsonschema==3.2.0
+hypothesis==4.57.1
+mypy_extensions==0.4.3
 nbval==0.9.5
 pyblake2==1.1.2; python_version < '3.6'
 pyinstaller==3.6
 pytest==4.6.9
-pytest-cov==2.7.1
+pytest-cov==2.8.1
 requests==2.22.0
-requests-mock==1.6.0
+requests-mock==1.7.0
 retrying>=1.3
-six==1.12.0
+six==1.14.0
 tqdm==4.42.1
 typing>=3.6.2; python_version < '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ futures==3.2.0; python_version < '3.2'
 jsonschema==3.0.2
 hypothesis==4.32.2
 mypy_extensions==0.4.1
-nbval==0.9.1
+nbval==0.9.5
 pyblake2==1.1.2; python_version < '3.6'
 pyinstaller==3.6
 pytest==4.6.9


### PR DESCRIPTION
This PR addresses #339 in providing a flag within the generate_clk function signature to use a ThreadPoolExecutor as opposed to ProcessPoolExecutor.  This change is propagated throughout the function signatures that implement generate_clk as well as the cli and benchmark cli. 

Documentation has also been updated to accommodate the change.