### PR TITLE
Fix schema v3

### DIFF
--- a/clkhash/schemas/v3.json
+++ b/clkhash/schemas/v3.json
@@ -72,6 +72,7 @@
       "properties": {
         "identifier": {"type": "string", "description": "semantic meaning of identifier"},
         "description": {"type": "string"},
+        "ignored": {"type": "boolean"},
         "format": {
           "required": ["type"],
           "oneOf": [

--- a/clkhash/schemas/v3.json
+++ b/clkhash/schemas/v3.json
@@ -57,6 +57,7 @@
     "ignoreFeature": {
       "type": "object",
       "required": ["identifier", "ignored"],
+      "additionalProperties": false,
       "properties": {
         "identifier": {"type": "string", "description":"semantic meaning of identifier"},
         "ignored":  {

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -204,6 +204,7 @@ name        type                   optional description
 identifier  string                 no       the name of the feature
 description string                 yes      free text, ignored by clkhash
 hashing     :ref:`schema/hashing`  no       configures feature specific hashing parameters
+ignored     boolean                yes      if set, clkhash will ignore this feature
 format      one of:                no       describes the expected format of the feature values
             :ref:`schema/tfo`,
             :ref:`schema/tpfo`,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -138,6 +138,11 @@ class TestSchemaValidation(unittest.TestCase):
         exception = contextmanager.exception
         self.assertIsInstance(exception, SchemaError)
 
+    def test_ignore_definitions(self):
+        # there are several valid ways of specifying the ignored property.
+        with open(_test_data_file_path('ignorant-schema-v3.json'), 'r') as f:
+            schema.from_json_file(f, validate=True)
+
 
 class TestSchemaLoading(unittest.TestCase):
     def test_issue_111(self):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -141,7 +141,10 @@ class TestSchemaValidation(unittest.TestCase):
     def test_ignore_definitions(self):
         # there are several valid ways of specifying the ignored property.
         with open(_test_data_file_path('ignorant-schema-v3.json'), 'r') as f:
-            schema.from_json_file(f, validate=True)
+            s = schema.from_json_file(f, validate=True)
+            self.assertIsInstance(s.fields[0], clkhash.field_formats.Ignore)
+            self.assertIsInstance(s.fields[1], clkhash.field_formats.Ignore)
+            self.assertIsInstance(s.fields[2], clkhash.field_formats.StringSpec)
 
 
 class TestSchemaLoading(unittest.TestCase):

--- a/tests/testdata/ignorant-schema-v3.json
+++ b/tests/testdata/ignorant-schema-v3.json
@@ -1,0 +1,62 @@
+
+{
+  "version": 3,
+  "clkConfig": {
+    "l": 1024,
+    "kdf": {
+      "type": "HKDF",
+      "hash": "SHA256",
+      "salt": "SCbL2zHNnmsckfzchsNkZY9XoHk96P/G5nUBrM7ybymlEFsMV6PAeDZCNp3rfNUPCtLDMOGQHG4pCQpfhiHCyA==",
+      "info": "c2NoZW1hX2V4YW1wbGU=",
+      "keySize": 64
+    }
+  },
+  "features": [
+    {
+      "identifier": "id",
+      "ignored": true,
+      "description": "whoOOOo are you? O-o"
+    },
+    {
+      "identifier": "firstName",
+      "format": {
+        "type": "string",
+        "encoding": "utf-8",
+        "maxLength": 30,
+        "case": "upper"
+      },
+      "hashing": {
+        "hash": {"type": "doubleHash"},
+        "comparison": {
+          "type": "ngram",
+          "n": 2
+        },
+        "strategy": {
+          "bitsPerFeature": 200
+        }
+      },
+      "ignored": true
+    },
+    {
+      "identifier": "middleNames",
+      "format": {
+        "type": "string",
+        "encoding": "utf-8",
+        "maxLength": 50,
+        "case": "upper",
+        "description": "comma separated list of middle names"
+      },
+      "hashing": {
+        "hash": {"type": "blakeHash"},
+        "comparison": {
+          "type": "ngram",
+          "n": 2
+        },
+        "strategy": {
+          "bitsPerToken": 20
+        }
+      },
+      "ignored": false
+    }
+  ]
+}


### PR DESCRIPTION
fixes #341

the schema validator couldn't decide which spec to apply if `"ignored": true` was added to a full feature config. More detail in #341