### PR TITLE
Add deprecation notice for rest_client and cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## new version
 
+## 0.15.2
+
+- Fixes bug validating linkage schemas with ignored fields. #342
+- Added warnings about upcoming removal of `rest_client` and `cli`. This functionality has
+  been migrated to [anonlink-client](https://github.com/data61/anonlink-client/)
+- Update dependencies
+
 ## 0.15.1
 
 - fixed issue where NumericComparison couldn't tokenize empty inputs #323

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -5,6 +5,7 @@ import json
 import os
 import shutil
 from multiprocessing import freeze_support
+import warnings
 
 import click
 
@@ -17,6 +18,11 @@ from clkhash.schema import SchemaError, validate_schema_dict, convert_to_latest_
 from clkhash.backports import raise_from
 
 from typing import List, Callable
+
+deprecation_notice = """
+Note that from version 0.15 the cli module of clkhash is deprecated. This functionality has
+been migrated to https://github.com/data61/anonlink-client
+"""
 
 DEFAULT_SERVICE_URL = 'https://testing.es.data61.xyz'
 
@@ -131,6 +137,7 @@ def cli(verbose):
 
     All rights reserved Confidential Computing 2016.
     """
+    warnings.warn(deprecation_notice, PendingDeprecationWarning)
 
 
 @cli.command('hash', short_help="generate hashes from local PII data")

--- a/clkhash/rest_client.py
+++ b/clkhash/rest_client.py
@@ -1,4 +1,5 @@
 import time
+import warnings
 
 import requests
 import clkhash
@@ -76,6 +77,9 @@ class RestClient:
             self.client_waiting_configuration = ClientWaitingConfiguration()
         else:
             self.client_waiting_configuration = client_waiting_configuration
+        deprecation_msg = "rest_client is being removed in the next release. " \
+                          "This functionality has been migrated to https://github.com/data61/anonlink-client"
+        warnings.warn(deprecation_msg, PendingDeprecationWarning)
 
     def __request_wrapper(self, request_method, url, **kwargs):
         """

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,6 +1,12 @@
 Command Line Tool
 =================
 
+.. warning::
+
+   Note that from version ``0.15.2`` the cli module of ``clkhash`` is **deprecated**. This functionality
+   has been migrated to https://github.com/data61/anonlink-client
+
+
 ``clkhash`` includes a command line tool which can be used to interact without writing Python code.
 The primary use case is to encode personally identifiable data from a csv into Cryptographic Longterm Keys.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,11 +16,11 @@ Install with pip::
 .. hint::
 
    If you are interested in comparing CLK encodings (i.e carrying out record linkage)
-   you might want to check out 
-   `anonlink <https://github.com/data61/anonlink>`_ and 
-   `anonlink-entity-service <https://github.com/data61/anonlink-entity-service>`__
-   - our Python library and REST service for computing
-   similarity scores, and matching between sets of cryptographic linkage keys.
+   you might want to check out these related projects:
+
+   - `anonlink <https://github.com/data61/anonlink>`_
+   - `anonlink <https://github.com/data61/anonlink-client>`_
+   - `anonlink-entity-service <https://github.com/data61/anonlink-entity-service>`__
 
 
 Table of Contents

--- a/docs/rest_client.rst
+++ b/docs/rest_client.rst
@@ -5,6 +5,12 @@ Rest Client API Documentation
 ``clkhash`` includes a module for interacting with the anonlink-entity-service.
 
 
+.. warning::
+
+   Note that from version ``0.15.2``, ``clkhash.rest_client`` is **deprecated**. This functionality
+   has been migrated to https://github.com/data61/anonlink-client
+
+
 .. automodule:: clkhash.rest_client
     :members:
     :undoc-members:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ else:
 
 setup(
     name="clkhash",
-    version='0.15.1',
+    version='0.15.2',
     description='Encoding utility to create Cryptographic Linkage Keys',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
As anonlink-client now implements the rest client and command line tool this functionality can be removed from clkhash.