### PR TITLE
remove typing from doc-requirements.txt

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -9,4 +9,3 @@ recordlinkage
 requests
 sphinx>=1.7
 sphinxcontrib-programoutput
-typing>=3.6


### PR DESCRIPTION
we don't need typing any more since it is part of python3.
Also, the inclusion of the typing lib makes the readthedoc build break.