### PR TITLE
Update tutorial_comparisons.ipynb

### DIFF
--- a/docs/tutorial_comparisons.ipynb
+++ b/docs/tutorial_comparisons.ipynb
@@ -266,7 +266,7 @@
     }
    ],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n"
+    "# NBVAL_IGNORE_OUTPUT\n",
     "import matplotlib.pyplot as plt\n",
     "plt.style.use('seaborn-deep')\n",
     "\n",
@@ -477,7 +477,7 @@
     }
    ],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n"
+    "# NBVAL_IGNORE_OUTPUT\n",
     "plt.style.use('seaborn-deep')\n",
     "\n",
     "plt.hist([sims_matches_unigram, sims_non_matches_unigram], bins=50, label=['matches', 'non-matches'])\n",

--- a/docs/tutorial_comparisons.ipynb
+++ b/docs/tutorial_comparisons.ipynb
@@ -266,6 +266,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n"
     "import matplotlib.pyplot as plt\n",
     "plt.style.use('seaborn-deep')\n",
     "\n",
@@ -476,6 +477,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n"
     "plt.style.use('seaborn-deep')\n",
     "\n",
     "plt.hist([sims_matches_unigram, sims_non_matches_unigram], bins=50, label=['matches', 'non-matches'])\n",


### PR DESCRIPTION
numpy throws a warning on how matplotlib is using it. This in turns throws the nbval notebook testing. For now, we ignore the output of the plots for the tests.