### PR TITLE
Fix strategy definition

### DIFF
--- a/clkhash/schemas/v3.json
+++ b/clkhash/schemas/v3.json
@@ -158,20 +158,26 @@
         [
           {
             "required": ["bitsPerToken"],
-            "bitsPerToken": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 20,
-              "description": "every token gets inserted into the Bloom filter exactly 'bitsPerToken' times."
+            "additionalProperties": false,
+            "properties": {
+              "bitsPerToken": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 20,
+                "description": "every token gets inserted into the Bloom filter exactly 'bitsPerToken' times."
+              }
             }
           },
           {
             "required": ["bitsPerFeature"],
-            "bitsPerFeature": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 200,
-              "description": "token get inserted into the Bloom filter a variable number of times such that the insertions of the tokens corresponding to one feature add up to 'bitsPerFeature'."
+            "additionalProperties": false,
+            "properties": {
+              "bitsPerFeature": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 200,
+                "description": "token get inserted into the Bloom filter a variable number of times such that the insertions of the tokens corresponding to one feature add up to 'bitsPerFeature'."
+              }
             }
           }
         ]},


### PR DESCRIPTION
the way the strategy was defined in the schema, one could specify
```"strategy": {"bitsPerToken": "illegalValue"}```
and the validation would not complain.
This PR fixes the definition of strategy in the schema.