### PR TITLE
fix deprecation warning, reduced hypothesis test cases range to somet…

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,11 +1,11 @@
 anonlink==0.13.1
 ipykernel==5.3.4
 nbval==0.9.6
-notebook==6.1.3
-matplotlib==3.3.1
+notebook==6.1.4
+matplotlib==3.3.2
 nbsphinx==0.7.1
-numpy==1.19.1
-pandas==1.1.1
+numpy==1.19.2
+pandas==1.1.3
 recordlinkage==0.14
 requests==2.24.0
 sphinx==3.2.1

--- a/tests/test_comparators.py
+++ b/tests/test_comparators.py
@@ -16,7 +16,7 @@ from clkhash.comparators import NgramComparison, NonComparison, ExactComparison,
 #######
 
 
-@fixture(params=itertools.product((1, 2, 3), (True, False)))
+@fixture(params=itertools.product((1, 2, 3), (True, False)), scope='module')
 def ngram_comparator(request):
     return comparators.NgramComparison(request.param[0], request.param[1])
 
@@ -118,10 +118,10 @@ def test_numeric_mix_int_and_floats():
 
 # we restrict the exponents of the floats such that exponent of number + precision < 308. Otherwise we might get
 # infinity during the tokenization process.
-@given(thresh_dist=floats(min_value=0.0, allow_nan=False, allow_infinity=False, max_value=1e287, exclude_min=True),
+@given(thresh_dist=floats(min_value=0.0, allow_nan=False, allow_infinity=False, max_value=1e20, exclude_min=True),
        resolution=integers(min_value=1, max_value=256),
        precision=integers(min_value=0, max_value=20),
-       candidate=floats(allow_nan=False, allow_infinity=False, max_value=1e288, min_value=-1e287))
+       candidate=floats(allow_nan=False, allow_infinity=False, max_value=1e20, min_value=-1e20))
 def test_numeric_properties(thresh_dist, resolution, precision, candidate):
     adj_dist = thresh_dist * pow(10, precision)
     if int(round(adj_dist)) <= 0:
@@ -135,10 +135,10 @@ def test_numeric_properties(thresh_dist, resolution, precision, candidate):
         assert len(set(tokens)) == 2 * resolution + 1, "tokens should be unique"
 
 
-@given(thresh_dist=floats(allow_infinity=False, allow_nan=False, min_value=0.0, max_value=1e287, exclude_min=True),
+@given(thresh_dist=floats(allow_infinity=False, allow_nan=False, min_value=0.0, max_value=1e20, exclude_min=True),
        resolution=integers(min_value=1, max_value=256),
        precision=integers(min_value=0, max_value=20),
-       candidate=floats(allow_infinity=False, allow_nan=False, max_value=1e287, min_value=-1e287))
+       candidate=floats(allow_infinity=False, allow_nan=False, max_value=1e20, min_value=-1e20))
 def test_numeric_overlaps_around_threshdistance(thresh_dist, resolution, precision, candidate):
     assume(int(round(thresh_dist * pow(10, precision))) > 0)
     comp = NumericComparison(threshold_distance=thresh_dist, resolution=resolution, fractional_precision=precision)
@@ -160,10 +160,10 @@ def test_numeric_overlaps_around_threshdistance(thresh_dist, resolution, precisi
         cand_tokens) - 2, "numbers that are not more than the modulus apart have all or all - 2 tokens in common"
 
 
-@given(thresh_dist=floats(allow_infinity=False, allow_nan=False, min_value=0.0, max_value=1e287, exclude_min=True),
+@given(thresh_dist=floats(allow_infinity=False, allow_nan=False, min_value=0.0, max_value=1e20, exclude_min=True),
        resolution=integers(min_value=1, max_value=256),
        precision=integers(min_value=0, max_value=20),
-       candidate=floats(allow_infinity=False, allow_nan=False, max_value=1e287, min_value=-1e287))
+       candidate=floats(allow_infinity=False, allow_nan=False, max_value=1e20, min_value=-1e20))
 def test_numeric_overlaps(thresh_dist, resolution, precision, candidate):
     assume(int(round(thresh_dist * pow(10, precision))) > 0)
     comp = NumericComparison(threshold_distance=thresh_dist, resolution=resolution, fractional_precision=precision)

--- a/tests/test_comparators.py
+++ b/tests/test_comparators.py
@@ -143,11 +143,16 @@ def test_numeric_overlaps_around_threshdistance(thresh_dist, resolution, precisi
     assume(int(round(thresh_dist * pow(10, precision))) > 0)
     comp = NumericComparison(threshold_distance=thresh_dist, resolution=resolution, fractional_precision=precision)
     other = candidate + thresh_dist
+    if other - candidate < thresh_dist:  # test for floating point errors
+        other += 2 * (thresh_dist - (other - candidate))  # if dist too small, we will get more than 1 token in common
     cand_tokens = comp.tokenize(str(candidate))
     other_tokens = comp.tokenize(str(other))
     if other != candidate:
-        assert len(set(cand_tokens).intersection(
-            set(other_tokens))) == 1, "numbers exactly thresh_dist apart have 1 token in common"
+        num_common_tokens = len(set(cand_tokens).intersection(set(other_tokens)))
+        if other - candidate == thresh_dist:
+            assert num_common_tokens == 1, "numbers exactly thresh_dist apart have 1 token in common"
+        else:
+            assert 0 <= num_common_tokens <= 2, "numbers close to thresh_dist apart have 0-2 tokens in common"
     other = candidate + thresh_dist * 1.51  # 0.5 because of the modulo operation
     assume((other - candidate) > (1.5 * thresh_dist))  # because of fp precision errors, 'other might not have changed'
     other_tokens = comp.tokenize(str(other))


### PR DESCRIPTION
…hing more sensible.

Testing with such huge ranges for threshold distance and candidates leads to some floating point weirdness. I think we can just test for numbers up to +/-1e20. That should cover most realistic use cases.