### PR TITLE
add blind run for pypy

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -18,6 +18,8 @@ class TestBenchmark(unittest.TestCase):
 
     @pytest.mark.skipif(IS_APPVEYOR and IS_PY3, reason="Windows benchmarking not working on Python3")
     def test_benchmarking_hash(self):
+        # blind run to give the JIT compiler of PyPy a chance to optimize
+        benchmark.compute_hash_speed(1000, quiet=True)
         speed = benchmark.compute_hash_speed(1000, quiet=True)
         try:
             assert speed > 100, "Hashing at less than 100 H/s"


### PR DESCRIPTION
We have a test that runs the benchmark and requires a certain speed.
PyPy struggled to jump over that hurdle, due to the JIT compiler.
In order to get a better picture of the true performance of PyPy, I added a blind run of the benchmark, such that the JIT compiler can optimize during that, and then we execute the benchmark again with those optimizations in place.


