### PR TITLE
Minor optimization to process futures as they complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## new version
 
+## 0.16.2
+
+- Minor change to `generate_clk_from_csv` and `generate_clks` to process results
+  as they complete.
+
+
 ## 0.16.1
 
 - `generate_clk_from_csv` and `generate_clks` now accept an optional `max_workers` argument.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name="clkhash",
-    version='0.16.1',
+    version='0.16.2',
     description='Encoding utility to create Cryptographic Linkage Keys',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I was having a look at clkhash internals thinking to propose a generator API as an alternative to the current approach of encoding all the data in one hit and returning a list of bitarrays. 

I noticed we were waiting on results from the encoding futures in the order the futures were created. This small PR changes that to use `concurrent.futures.as_completed` instead.

