### PR TITLE
Rename main branch

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [ published ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ main ]
 
 jobs:
   build_dist:

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -2,9 +2,9 @@ name: Typechecking
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ main ]
 
 
 jobs:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -5,9 +5,9 @@ name: Unit Testing
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ main ]
 
 jobs:
   unittests:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <div align="center">
 
-[![codecov](https://codecov.io/gh/data61/clkhash/branch/master/graph/badge.svg)](https://codecov.io/gh/data61/clkhash)
+[![codecov](https://codecov.io/gh/data61/clkhash/branch/main/graph/badge.svg)](https://codecov.io/gh/data61/clkhash)
 [![Documentation Status](https://readthedocs.org/projects/clkhash/badge/?version=latest)](http://clkhash.readthedocs.io/en/latest/?badge=latest)
 [![Unit Testing](https://github.com/data61/clkhash/actions/workflows/unittests.yml/badge.svg)](https://github.com/data61/clkhash/actions/workflows/unittests.yml)
 [![Typechecking](https://github.com/data61/clkhash/actions/workflows/typechecking.yml/badge.svg)](https://github.com/data61/clkhash/actions/workflows/typechecking.yml)

--- a/docs/devops.rst
+++ b/docs/devops.rst
@@ -71,7 +71,7 @@ Release Pipeline
 ~~~~~~~~~~~~~~~~
 
 The release pipeline can either be triggered manually, or automatically from
-a successful build on master where the build is tagged `Automated`
+a successful build on `main` where the build is tagged `Automated`
 (i.e. if the commit is tagged, cf previous paragraph). 
 
 The release pipeline consists of two steps: 

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -20,7 +20,7 @@ encoding operation, along with any configuration for the low level hashing itsel
 
 The format of the linkage schema is defined in a separate
 `JSON Schema <https://json-schema.org/specification.html>`_ specification document -
-`schemas/v3.json <https://github.com/data61/clkhash/blob/master/clkhash/schemas/v3.json>`_.
+`schemas/v3.json <https://github.com/data61/clkhash/blob/main/clkhash/schemas/v3.json>`_.
 
 Earlier versions of the linkage schema will continue to work, internally they
 are converted to the latest version (currently ``v3``).

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -16,10 +16,10 @@ running the tutorials
 The notebooks can run online using binder.
 
 .. image:: https://mybinder.org/badge_logo.svg
-  :target: https://mybinder.org/v2/gh/data61/clkhash/master?filepath=docs
+  :target: https://mybinder.org/v2/gh/data61/clkhash/main?filepath=docs
 
 
-You can download the tutorials from `github <https://github.com/data61/clkhash/tree/master/docs>`_.
+You can download the tutorials from `github <https://github.com/data61/clkhash/tree/main/docs>`_.
 The dependencies are listed in `doc-requirements.txt`. Install and start Jupyter from the ``docs``
 directory::
 


### PR DESCRIPTION
I've renamed in GitHub, this PR just updates the docs.

Users that already have the project checked out may have to run:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```